### PR TITLE
add 'databaseInstance' parameter to @Flyway annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 *.iml
 *.ipr
 .~*
+.envrc

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>space.testflight</groupId>
   <artifactId>testflight</artifactId>
-  <version>0.1.4-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
 
   <name>Testflight.Space</name>
   <url>http://www.testflight.space</url>
@@ -129,6 +129,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/checkstyle/configuration.xml
+++ b/src/main/checkstyle/configuration.xml
@@ -124,7 +124,7 @@
 	  <property name="throwsIndent" value="4"/>
 	  <property name="arrayInitIndent" value="2"/>
 	  <property name="lineWrappingIndentation" value="2"/>
-	  <property name="forceStrictCondition" value="true"/>
+	  <property name="forceStrictCondition" value="false"/>
 	</module>
     <module name="InnerAssignment"/>
     <module name="InnerTypeLast"/>

--- a/src/main/checkstyle/test-configuration.xml
+++ b/src/main/checkstyle/test-configuration.xml
@@ -124,7 +124,7 @@
 	  <property name="throwsIndent" value="4"/>
 	  <property name="arrayInitIndent" value="2"/>
 	  <property name="lineWrappingIndentation" value="2"/>
-	  <property name="forceStrictCondition" value="true"/>
+	  <property name="forceStrictCondition" value="false"/>
 	</module>
     <module name="InnerAssignment"/>
     <module name="InnerTypeLast"/>

--- a/src/main/java/space/testflight/Flyway.java
+++ b/src/main/java/space/testflight/Flyway.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface Flyway {
   DatabaseType database() default DatabaseType.POSTGRESQL;
   String dockerImage() default "";
+  DatabaseInstance databaseInstance() default DatabaseInstance.PER_TEST_METHOD;
   String[] testDataScripts() default {};
   ConfigProperty[] configuration() default {};
 
@@ -50,5 +51,11 @@ public @interface Flyway {
     public String getImage(String tag) {
       return getImage() + ":" + tag;
     }
+  }
+
+  enum DatabaseInstance {
+    PER_TEST_EXECUTION, // after @BeforeEach works with parameterized tests
+    PER_TEST_METHOD,    // before @BeforeEach
+    PER_TEST_CLASS      // before @BeforeAll
   }
 }

--- a/src/test/java/space/testflight/postgresql/DefaultDatabaseTest.java
+++ b/src/test/java/space/testflight/postgresql/DefaultDatabaseTest.java
@@ -75,11 +75,8 @@ public class DefaultDatabaseTest {
 
     List<Customer> customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
 
-    assertThat(customers).hasSize(4);
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Hans"));
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Admin")); // in flyway script
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Admin2")); // in flyway script
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Admin3")); // in flyway script
+    assertThat(customers).hasSize(4)
+            .extracting(Customer::getUserName).containsExactlyInAnyOrder("Hans", "Admin", "Admin2", "Admin3"); // admins in flyway script
   }
 
   @Test
@@ -92,10 +89,7 @@ public class DefaultDatabaseTest {
 
     List<Customer> customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
 
-    assertThat(customers).hasSize(4);
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Peter"));
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Admin")); // in flyway script
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Admin2")); // in flyway script
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Admin3")); // in flyway script
+    assertThat(customers).hasSize(4)
+            .extracting(Customer::getUserName).containsExactlyInAnyOrder("Peter", "Admin", "Admin2", "Admin3"); // admins in flyway script
   }
 }

--- a/src/test/java/space/testflight/postgresql/PerTestExecutionTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestExecutionTest.java
@@ -40,7 +40,7 @@ import space.testflight.model.Customer;
 
 @Flyway(
   database = Flyway.DatabaseType.POSTGRESQL,
-  databaseInstance = Flyway.DatabaseInstance.PER_TEST_METHOD,
+  databaseInstance = Flyway.DatabaseInstance.PER_TEST_EXECUTION,
   configuration = {
     @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
     @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),

--- a/src/test/java/space/testflight/postgresql/PerTestExecutionTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestExecutionTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 Arne Limburg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.NoResultException;
+import javax.persistence.Persistence;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+import space.testflight.model.Customer;
+
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstance.PER_TEST_METHOD,
+  configuration = {
+    @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+    @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+    @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+  })
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+public class PerTestExecutionTest {
+
+  private static EntityManagerFactory entityManagerFactory;
+  private EntityManager entityManager;
+
+  @BeforeAll
+  static void createEntityManagerFactory() {
+    entityManagerFactory = Persistence.createEntityManagerFactory("test-unit", System.getProperties());
+  }
+
+  @AfterAll
+  static void closeEntityManagerFactory() {
+    entityManagerFactory.close();
+  }
+
+  @BeforeEach
+  void createEntityManager() {
+    entityManager = entityManagerFactory.createEntityManager();
+  }
+
+  @AfterEach
+  void closeEntityManager() {
+    entityManager.close();
+  }
+
+  @Test
+  void aaainsertCustomer() {
+    assertThat(getHans()).isNull();
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(new Customer("Hans", "hans@mail.de"));
+    entityManager.getTransaction().commit();
+
+    assertThat(getHans().getUserName()).isEqualTo("Hans");
+  }
+
+  @Test
+  void bbbinsertedCustomerDoesNoLongerExist() {
+    assertThat(getHans()).isNull(); // container replaced with every method
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Georg", "Gregor"})
+  void parameterizedTestsReceiveTheirOwnContainer(String username) {
+
+    List<Customer> customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
+    assertThat(customers).hasSize(3);
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(new Customer(username, username + "@mail.de"));
+    entityManager.getTransaction().commit();
+
+    customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
+    assertThat(customers).hasSize(4)
+      .extracting(Customer::getUserName).contains(username);
+  }
+
+  private Customer getHans() {
+    try {
+      return entityManager.createQuery("Select u from Customer u where u.userName = 'Hans'", Customer.class).getSingleResult();
+    } catch (NoResultException e) {
+      return null;
+    }
+  }
+}

--- a/src/test/java/space/testflight/postgresql/PerTestMethodTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestMethodTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 Arne Limburg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.NoResultException;
+import javax.persistence.Persistence;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+import space.testflight.model.Customer;
+
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstance.PER_TEST_METHOD,
+  configuration = {
+    @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+    @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+    @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+  })
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+public class PerTestMethodTest {
+
+  private static EntityManagerFactory entityManagerFactory;
+  private EntityManager entityManager;
+
+  @BeforeAll
+  static void createEntityManagerFactory() {
+    entityManagerFactory = Persistence.createEntityManagerFactory("test-unit", System.getProperties());
+  }
+
+  @AfterAll
+  static void closeEntityManagerFactory() {
+    entityManagerFactory.close();
+  }
+
+  @BeforeEach
+  void createEntityManager() {
+    entityManager = entityManagerFactory.createEntityManager();
+
+    // accessing DB in BeforeEach works with PER_TEST_METHOD
+    List<Customer> customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
+    assertThat(customers).hasSize(3);
+  }
+
+  @AfterEach
+  void closeEntityManager() {
+    entityManager.close();
+  }
+
+  @Test
+  void aaainsertCustomer() {
+    assertThat(getHans()).isNull();
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(new Customer("Hans", "hans@mail.de"));
+    entityManager.getTransaction().commit();
+
+    assertThat(getHans().getUserName()).isEqualTo("Hans");
+  }
+
+  @Test
+  void bbbinsertedCustomerDoesNoLongerExist() {
+    assertThat(getHans()).isNull(); // container replaced with every method
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Georg", "Gregor"})
+  void parameterizedTestsReceiveTheirOwnContainer(String username) {
+
+    List<Customer> customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
+    assertThat(customers).hasSize(3);
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(new Customer(username, username + "@mail.de"));
+    entityManager.getTransaction().commit();
+
+    customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
+    assertThat(customers).hasSize(4)
+      .extracting(Customer::getUserName).contains(username);
+  }
+
+  private Customer getHans() {
+    try {
+      return entityManager.createQuery("Select u from Customer u where u.userName = 'Hans'", Customer.class).getSingleResult();
+    } catch (NoResultException e) {
+      return null;
+    }
+  }
+}

--- a/src/test/java/space/testflight/postgresql/SecondPostgreSqlTest.java
+++ b/src/test/java/space/testflight/postgresql/SecondPostgreSqlTest.java
@@ -75,11 +75,11 @@ public class SecondPostgreSqlTest {
 
     List<Customer> customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
 
-    assertThat(customers).hasSize(6);
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Hans"));
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Admin")); // in flyway script
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("tesdataUser")); // in init script
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("tesdataUser2")); // in second init script
+    assertThat(customers).hasSize(6).extracting(Customer::getUserName)
+      .contains("Hans")
+      .contains("Admin") // in flyway script
+      .contains("tesdataUser") // in init script
+      .contains("tesdataUser2"); // in second init script
   }
 
   @Test
@@ -92,10 +92,10 @@ public class SecondPostgreSqlTest {
 
     List<Customer> customers = entityManager.createQuery("Select u from Customer u", Customer.class).getResultList();
 
-    assertThat(customers).hasSize(6);
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Peter"));
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("Admin")); // in flyway script
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("tesdataUser")); // in init script
-    assertThat(customers).anyMatch(c -> c.getUserName().equals("tesdataUser2")); // in second init script
+    assertThat(customers).hasSize(6).extracting(Customer::getUserName)
+      .contains("Peter")
+      .contains("Admin") // in flyway script
+      .contains("tesdataUser") // in init script
+      .contains("tesdataUser2"); // in second init script
   }
 }


### PR DESCRIPTION
Add `databaseInstance` parameter to `@Flyway` annotation to choose between `PER_TEST_EXECUTION`, `PER_TEST_METHOD`, `PER_TEST_CLASS` DB lifecycle.