### PR TITLE
Add support for dbrider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
         <artifactId>postgresql</artifactId>
         <version>42.2.17</version>
       </dependency>
+      <dependency>
+        <groupId>com.github.database-rider</groupId>
+        <artifactId>rider-core</artifactId>
+        <version>1.23.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -117,6 +122,11 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.github.database-rider</groupId>
+      <artifactId>rider-core</artifactId>
       <optional>true</optional>
     </dependency>
 
@@ -158,6 +168,12 @@
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
       <version>0.9.5.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.database-rider</groupId>
+      <artifactId>rider-junit5</artifactId>
+      <version>1.23.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
       </dependency>
       <dependency>
         <groupId>com.github.database-rider</groupId>
-        <artifactId>rider-core</artifactId>
+        <artifactId>rider-junit5</artifactId>
         <version>1.23.0</version>
       </dependency>
     </dependencies>
@@ -126,7 +126,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.database-rider</groupId>
-      <artifactId>rider-core</artifactId>
+      <artifactId>rider-junit5</artifactId>
       <optional>true</optional>
     </dependency>
 
@@ -168,12 +168,6 @@
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
       <version>0.9.5.4</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.database-rider</groupId>
-      <artifactId>rider-junit5</artifactId>
-      <version>1.23.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/space/testflight/TestResource.java
+++ b/src/main/java/space/testflight/TestResource.java
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package space.testflight.dbrider;
+package space.testflight;
 
-import com.github.database.rider.core.api.connection.ConnectionHolder;
+import static java.lang.annotation.ElementType.FIELD;
 
-import space.testflight.TestResource;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public abstract class AbstractDbRiderEnabledTest {
-
-  @TestResource
-  protected ConnectionHolder connectionHolder;  // dbRider accesses this field with reflections
+/**
+ * {@code @TestResource} is used to signal that the annotated field in a test class
+ * should be injected with a DBRider ConnectionHolder by testflight.
+ */
+@Target({FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestResource {
 }

--- a/src/test/java/space/testflight/dbrider/AbstractDbRiderEnabledTest.java
+++ b/src/test/java/space/testflight/dbrider/AbstractDbRiderEnabledTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Arne Limburg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.dbrider;
+
+import com.github.database.rider.core.api.connection.ConnectionHolder;
+
+public abstract class AbstractDbRiderEnabledTest {
+
+  protected ConnectionHolder connectionHolder;  // dbRider accesses this field with reflections
+}

--- a/src/test/java/space/testflight/dbrider/AbstractDbRiderEnabledTest.java
+++ b/src/test/java/space/testflight/dbrider/AbstractDbRiderEnabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Arne Limburg
+ * Copyright 2021 Roman Ness
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/space/testflight/dbrider/ConnectionFieldInjectionTest.java
+++ b/src/test/java/space/testflight/dbrider/ConnectionFieldInjectionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Roman Ness
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.dbrider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+
+import org.junit.jupiter.api.Test;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+import space.testflight.TestResource;
+
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+  configuration = {
+  @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+  @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+  @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+})
+public class ConnectionFieldInjectionTest {
+
+  @TestResource
+  private Connection connection;
+
+  @Test
+  void connectionHolderFieldIsIgnoredBecauseOfWrongType() {
+    assertThat(connection).isNotNull();
+  }
+}

--- a/src/test/java/space/testflight/dbrider/ConnectionFieldWithWrongTypeTest.java
+++ b/src/test/java/space/testflight/dbrider/ConnectionFieldWithWrongTypeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Roman Ness
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.dbrider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+import space.testflight.TestResource;
+
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+  configuration = {
+  @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+  @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+  @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+})
+public class ConnectionFieldWithWrongTypeTest {
+
+  @TestResource
+  private Object connection;  // field has wrong type and is ignored
+
+  @Test
+  void connectionFieldIsIgnoredBecauseOfWrongType() {
+    assertThat(connection).isNull();
+  }
+}

--- a/src/test/java/space/testflight/dbrider/ConnectionFieldWithoutAnnotationTest.java
+++ b/src/test/java/space/testflight/dbrider/ConnectionFieldWithoutAnnotationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Roman Ness
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.dbrider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+
+import org.junit.jupiter.api.Test;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+  configuration = {
+  @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+  @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+  @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+})
+public class ConnectionFieldWithoutAnnotationTest {
+
+  private Connection connection;  // field is missing TestResource and is ignored
+
+  @Test
+  void connectionFieldIsIgnoredBecauseOfWrongType() {
+    assertThat(connection).isNull();
+  }
+}

--- a/src/test/java/space/testflight/dbrider/ConnectionHolderFieldWithWrongTypeTest.java
+++ b/src/test/java/space/testflight/dbrider/ConnectionHolderFieldWithWrongTypeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Roman Ness
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.dbrider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+import space.testflight.TestResource;
+
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+  configuration = {
+  @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+  @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+  @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+})
+public class ConnectionHolderFieldWithWrongTypeTest {
+
+  @TestResource
+  private Object connectionHolder;  // field has wrong type and is ignored
+
+  @Test
+  void connectionHolderFieldIsIgnoredBecauseOfWrongType() {
+    assertThat(connectionHolder).isNull();
+  }
+}

--- a/src/test/java/space/testflight/dbrider/ConnectionHolderFieldWithoutAnnotationTest.java
+++ b/src/test/java/space/testflight/dbrider/ConnectionHolderFieldWithoutAnnotationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Roman Ness
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.dbrider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.database.rider.core.api.connection.ConnectionHolder;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+  configuration = {
+  @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+  @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+  @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+})
+public class ConnectionHolderFieldWithoutAnnotationTest {
+
+  private ConnectionHolder connectionHolder;  // field is missing TestResource and is ignored
+
+  @Test
+  void connectionHolderFieldIsIgnoredBecauseOfWrongType() {
+    assertThat(connectionHolder).isNull();
+  }
+}

--- a/src/test/java/space/testflight/dbrider/DbRiderTest.java
+++ b/src/test/java/space/testflight/dbrider/DbRiderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Arne Limburg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.dbrider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.NoResultException;
+import javax.persistence.Persistence;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.configuration.Orthography;
+import com.github.database.rider.core.api.connection.ConnectionHolder;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.SeedStrategy;
+import com.github.database.rider.junit5.api.DBRider;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+import space.testflight.model.Customer;
+
+@DBRider
+@DBUnit(schema = "public", caseInsensitiveStrategy = Orthography.LOWERCASE)
+@DataSet(value = "dbrider/customers.yml", strategy = SeedStrategy.INSERT)
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+  configuration = {
+  @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+  @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+  @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+})
+public class DbRiderTest {
+
+  private static EntityManagerFactory entityManagerFactory;
+
+  private ConnectionHolder connectionHolder;  // dbRider accesses this field with reflections
+
+  private EntityManager entityManager;
+
+  @BeforeAll
+  static void createEntityManagerFactory() {
+    entityManagerFactory = Persistence.createEntityManagerFactory("test-unit", System.getProperties());
+  }
+
+  @AfterAll
+  static void closeEntityManagerFactory() {
+    entityManagerFactory.close();
+  }
+
+  @BeforeEach
+  void createEntityManager() {
+    entityManager = entityManagerFactory.createEntityManager();
+
+  }
+
+  @AfterEach
+  void closeEntityManager() {
+    entityManager.close();
+  }
+
+
+  @Test
+  void deleteUser() {
+    assertThatUserWereCreatedByDbRider();
+
+    entityManager.getTransaction().begin();
+    entityManager.createQuery("Delete from Customer u where u.userName = 'dbrider'").executeUpdate();
+    entityManager.getTransaction().commit();
+
+    assertThat(loadUser("dbrider")).isNull();
+  }
+
+  @Test
+  void createUser() {
+    assertThatUserWereCreatedByDbRider();
+
+    assertThat(loadUser("Hans")).isNull();
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(new Customer("Hans", "hans@mail.de"));
+    entityManager.getTransaction().commit();
+
+    assertThat(loadUser("Hans").getUserName()).isEqualTo("Hans");
+  }
+
+  private void assertThatUserWereCreatedByDbRider() {
+    Customer customer =
+      entityManager.createQuery("Select u from Customer u where u.userName = 'dbrider'", Customer.class).getSingleResult();
+    assertThat(customer).isNotNull();
+  }
+
+  private Customer loadUser(String username) {
+    try {
+      return entityManager.createQuery(String.format("Select u from Customer u where u.userName = '%s'", username), Customer.class)
+        .getSingleResult();
+    } catch (NoResultException e) {
+      return null;
+    }
+  }
+}

--- a/src/test/java/space/testflight/dbrider/DbRiderTest.java
+++ b/src/test/java/space/testflight/dbrider/DbRiderTest.java
@@ -37,6 +37,7 @@ import com.github.database.rider.junit5.api.DBRider;
 
 import space.testflight.ConfigProperty;
 import space.testflight.Flyway;
+import space.testflight.TestResource;
 import space.testflight.model.Customer;
 
 @DBRider
@@ -54,6 +55,7 @@ public class DbRiderTest {
 
   private static EntityManagerFactory entityManagerFactory;
 
+  @TestResource
   private ConnectionHolder connectionHolder;  // dbRider accesses this field with reflections
 
   private EntityManager entityManager;
@@ -79,6 +81,11 @@ public class DbRiderTest {
     entityManager.close();
   }
 
+
+  @Test
+  void connectionHolderFieldIsInjected() {
+    assertThat(connectionHolder).isNotNull();
+  }
 
   @Test
   void deleteUser() {

--- a/src/test/java/space/testflight/dbrider/DbRiderTest.java
+++ b/src/test/java/space/testflight/dbrider/DbRiderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Arne Limburg
+ * Copyright 2021 Roman Ness
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/space/testflight/dbrider/DbRiderWithFieldInSuperClassTest.java
+++ b/src/test/java/space/testflight/dbrider/DbRiderWithFieldInSuperClassTest.java
@@ -77,6 +77,11 @@ public class DbRiderWithFieldInSuperClassTest extends AbstractDbRiderEnabledTest
 
 
   @Test
+  void connectionHolderFieldIsInjected() {
+    assertThat(connectionHolder).isNotNull();
+  }
+
+  @Test
   void deleteUser() {
     assertThatUserWereCreatedByDbRider();
 

--- a/src/test/java/space/testflight/dbrider/DbRiderWithFieldInSuperClassTest.java
+++ b/src/test/java/space/testflight/dbrider/DbRiderWithFieldInSuperClassTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 Arne Limburg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.dbrider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.NoResultException;
+import javax.persistence.Persistence;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.configuration.Orthography;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.SeedStrategy;
+import com.github.database.rider.junit5.api.DBRider;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+import space.testflight.model.Customer;
+
+@DBRider
+@DBUnit(schema = "public", caseInsensitiveStrategy = Orthography.LOWERCASE)
+@DataSet(value = "dbrider/customers.yml", strategy = SeedStrategy.INSERT)
+@Flyway(
+  database = Flyway.DatabaseType.POSTGRESQL,
+  databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+  configuration = {
+  @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+  @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+  @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+})
+public class DbRiderWithFieldInSuperClassTest extends AbstractDbRiderEnabledTest {
+
+  private static EntityManagerFactory entityManagerFactory;
+  private EntityManager entityManager;
+
+  @BeforeAll
+  static void createEntityManagerFactory() {
+    entityManagerFactory = Persistence.createEntityManagerFactory("test-unit", System.getProperties());
+  }
+
+  @AfterAll
+  static void closeEntityManagerFactory() {
+    entityManagerFactory.close();
+  }
+
+  @BeforeEach
+  void createEntityManager() {
+    entityManager = entityManagerFactory.createEntityManager();
+
+  }
+
+  @AfterEach
+  void closeEntityManager() {
+    entityManager.close();
+  }
+
+
+  @Test
+  void deleteUser() {
+    assertThatUserWereCreatedByDbRider();
+
+    entityManager.getTransaction().begin();
+    entityManager.createQuery("Delete from Customer u where u.userName = 'dbrider'").executeUpdate();
+    entityManager.getTransaction().commit();
+
+    assertThat(loadUser("dbrider")).isNull();
+  }
+
+  @Test
+  void createUser() {
+    assertThatUserWereCreatedByDbRider();
+
+    assertThat(loadUser("Hans")).isNull();
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(new Customer("Hans", "hans@mail.de"));
+    entityManager.getTransaction().commit();
+
+    assertThat(loadUser("Hans").getUserName()).isEqualTo("Hans");
+  }
+
+  private void assertThatUserWereCreatedByDbRider() {
+    Customer customer =
+      entityManager.createQuery("Select u from Customer u where u.userName = 'dbrider'", Customer.class).getSingleResult();
+    assertThat(customer).isNotNull();
+  }
+
+  private Customer loadUser(String username) {
+    try {
+      return entityManager.createQuery(String.format("Select u from Customer u where u.userName = '%s'", username), Customer.class)
+        .getSingleResult();
+    } catch (NoResultException e) {
+      return null;
+    }
+  }
+}

--- a/src/test/java/space/testflight/dbrider/DbRiderWithFieldInSuperClassTest.java
+++ b/src/test/java/space/testflight/dbrider/DbRiderWithFieldInSuperClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Arne Limburg
+ * Copyright 2021 Roman Ness
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/space/testflight/postgresql/PerTestClassTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arne Limburg
+ * Copyright 2020 Roman Ness
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/space/testflight/postgresql/PerTestExecutionTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arne Limburg
+ * Copyright 2020 Roman Ness
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/space/testflight/postgresql/PerTestMethodTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arne Limburg
+ * Copyright 2020 Roman Ness
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/dbrider/customers.yml
+++ b/src/test/resources/dbrider/customers.yml
@@ -1,0 +1,4 @@
+customer:
+  - id: 42
+    username: dbrider
+    email: db@rider.net


### PR DESCRIPTION
Injects the `connectionHolder` field in test classes with a proxied Connection to enable support for DBRider.