### PR TITLE
Patch issue 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.5</version>
+        <version>0.8.7</version>
         <executions>
           <execution>
             <id>default-prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-testkit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/space/testflight/FlywayExtension.java
+++ b/src/main/java/space/testflight/FlywayExtension.java
@@ -127,6 +127,8 @@ public class FlywayExtension implements BeforeAllCallback, BeforeEachCallback, B
     if (getDatabaseInstance(context) == Flyway.DatabaseInstanceScope.PER_TEST_CLASS) {
       teardownDb(context, false);
     }
+
+    getGlobalStore(context).get(STORE_CONTAINER, AutoCloseable.class).close();
   }
 
   @Override

--- a/src/test/java/space/testflight/lifecycle/AbstractJupiterTestEngineTests.java
+++ b/src/test/java/space/testflight/lifecycle/AbstractJupiterTestEngineTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Marvin Kienitz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package space.testflight.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.engine.JupiterTestEngine;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.ClassSelector;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+public class AbstractJupiterTestEngineTests {
+  private final JupiterTestEngine engine = new JupiterTestEngine();
+
+  protected EngineExecutionResults executeTestsForClasses(Class<?>... testClasses) {
+    final ClassSelector[] classSelectors = Arrays.stream(testClasses)
+      .map(DiscoverySelectors::selectClass)
+      .collect(Collectors.toList())
+      .toArray(new ClassSelector[]{});
+
+    return executeTests(classSelectors);
+  }
+
+  protected EngineExecutionResults executeTestsForClass(Class<?> testClass) {
+    return executeTests(selectClass(testClass));
+  }
+
+  protected EngineExecutionResults executeTests(DiscoverySelector... selectors) {
+    return executeTests(request().selectors(selectors).build());
+  }
+
+  protected EngineExecutionResults executeTests(LauncherDiscoveryRequest request) {
+    return EngineTestKit.execute(this.engine, request);
+  }
+
+  protected TestDescriptor discoverTests(DiscoverySelector... selectors) {
+    return discoverTests(request().selectors(selectors).build());
+  }
+
+  protected TestDescriptor discoverTests(LauncherDiscoveryRequest request) {
+    return engine.discover(request, UniqueId.forEngine(engine.getId()));
+  }
+
+  protected UniqueId discoverUniqueId(Class<?> clazz, String methodName) {
+    TestDescriptor engineDescriptor = discoverTests(selectMethod(clazz, methodName));
+    Set<? extends TestDescriptor> descendants = engineDescriptor.getDescendants();
+    // @formatter:off
+    TestDescriptor testDescriptor = descendants.stream()
+      .skip(descendants.size() - 1)
+      .findFirst()
+      .orElseGet(() -> fail("no descendants"));
+    // @formatter:on
+    return testDescriptor.getUniqueId();
+  }
+}

--- a/src/test/java/space/testflight/lifecycle/DisabledMethodsTest.java
+++ b/src/test/java/space/testflight/lifecycle/DisabledMethodsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Marvin Kienitz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package space.testflight.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+
+import space.testflight.ConfigProperty;
+import space.testflight.Flyway;
+
+public class DisabledMethodsTest extends AbstractJupiterTestEngineTests {
+
+  @Test
+  public void executeTestsWithDisabledTestClass() {
+    assertThatNoException().isThrownBy(() -> {
+      EngineExecutionResults results = executeTestsForClasses(
+        TestClassWithOnlyDisabledTestMethodsTestCase.class,
+        TestClassWithNonDisabledTestMethodsTestCase.class
+      );
+
+      assertThat(results.testEvents().started().count()).isEqualTo(1);
+      assertThat(results.testEvents().skipped().count()).isEqualTo(1);
+      assertThat(results.testEvents().succeeded().count()).isEqualTo(1);
+      assertThat(results.testEvents().failed().count()).isZero();
+    });
+  }
+
+  @Flyway(
+    database = Flyway.DatabaseType.POSTGRESQL,
+    databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+    configuration = {
+    @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+    @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+    @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+  })
+  public static class TestClassWithOnlyDisabledTestMethodsTestCase {
+    @Test
+    @Disabled
+    public void testMethodDisabled() { }
+  }
+
+  @Flyway(
+    database = Flyway.DatabaseType.POSTGRESQL,
+    databaseInstance = Flyway.DatabaseInstanceScope.PER_TEST_METHOD,
+    configuration = {
+    @ConfigProperty(key = "space.testflight.jdbc.url.property", value = "javax.persistence.jdbc.url"),
+    @ConfigProperty(key = "space.testflight.jdbc.username.property", value = "javax.persistence.jdbc.user"),
+    @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
+  })
+  public static class TestClassWithNonDisabledTestMethodsTestCase {
+    @Test
+    public void testMethodNonDisabled() { }
+  }
+}


### PR DESCRIPTION
# About
Resolves #5 by stopping the container, after a test-class was executed.

# Description
* bumped jacoco to `0.8.7`, so it supports JDK 17 and older (see [https://github.com/gradle/gradle/issues/15038](https://github.com/gradle/gradle/issues/15038))
* added `org.junit.platform:junit-platform-testkit` to be able to start the engine manually
* added `AbstractJupiterTestEngineTests.java` (based on [an internal junit5 class](https://github.com/junit-team/junit5/blob/main/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java))
* added `DisabledMethodsTest.java` to reproduce the issue