### PR TITLE
Update dependencies and correct usage of deprecated API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>space.testflight</groupId>
   <artifactId>testflight</artifactId>
-  <version>0.9.3-SNAPSHOT</version>
+  <version>0.9.3</version>
 
   <name>Testflight.Space</name>
   <url>https://www.testflight.space</url>

--- a/pom.xml
+++ b/pom.xml
@@ -8,15 +8,14 @@
   <version>0.9.3-SNAPSHOT</version>
 
   <name>Testflight.Space</name>
-  <url>http://www.testflight.space</url>
+  <url>https://www.testflight.space</url>
   <description>
-    A JUnit 5 extension to write fast database tests with testcontainers 
-and flyway or liquibase.
+    A JUnit 5 extension to write fast database tests with testcontainers and flyway or liquibase.
   </description>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
   
@@ -53,10 +52,12 @@ and flyway or liquibase.
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 
-    <jupiter.version>5.6.2</jupiter.version>
-    <testcontainers.version>1.17.6</testcontainers.version>
-    <flyway.version>9.15.2</flyway.version>
-    <liquibase.version>4.18.0</liquibase.version>
+    <jupiter.version>5.9.3</jupiter.version>
+    <testcontainers.version>1.18.3</testcontainers.version>
+    <flyway.version>9.20.1</flyway.version>
+    <liquibase.version>4.22.0</liquibase.version>
+    <spring.boot.version>2.5.15</spring.boot.version>
+    <hibernate.version>5.6.15.Final</hibernate.version>
 
     <sonar.projectKey>ArneLimburg_testflight</sonar.projectKey>
     <sonar.organization>arnelimburg-github</sonar.organization>
@@ -93,17 +94,17 @@ and flyway or liquibase.
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.8</version>
+        <version>42.6.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.database-rider</groupId>
         <artifactId>rider-junit5</artifactId>
-        <version>1.23.0</version>
+        <version>1.39.0</version>
       </dependency>
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>8.0.28</version>
+        <version>8.0.33</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -153,7 +154,7 @@ and flyway or liquibase.
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.17.2</version>
+      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -179,19 +180,19 @@ and flyway or liquibase.
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <scope>test</scope>
-      <version>2.5.2</version>
+      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
       <scope>test</scope>
-      <version>2.5.2</version>
+      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <version>2.5.2</version>
+      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.persistence</groupId>
@@ -202,19 +203,19 @@ and flyway or liquibase.
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <version>5.4.21.Final</version>
+      <version>${hibernate.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-c3p0</artifactId>
-      <version>5.4.21.Final</version>
+      <version>${hibernate.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-      <version>0.9.5.4</version>
+      <version>0.9.5.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -222,20 +223,24 @@ and flyway or liquibase.
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.1</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.1</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <id>default-test</id>
@@ -266,17 +271,19 @@ and flyway or liquibase.
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.0.1</version>
         <configuration>
           <tagNameFormat>@{project.version}</tagNameFormat>
         </configuration>
@@ -284,7 +291,7 @@ and flyway or liquibase.
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
@@ -295,8 +302,9 @@ and flyway or liquibase.
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -310,7 +318,7 @@ and flyway or liquibase.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -321,8 +329,9 @@ and flyway or liquibase.
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -340,18 +349,18 @@ and flyway or liquibase.
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.3.0</version>
         <configuration>
           <consoleOutput>true</consoleOutput>
-          <encoding>UTF-8</encoding>
           <headerLocation>${project.basedir}/src/main/checkstyle/java.header</headerLocation>
         </configuration>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>9.2.1</version>
+            <version>10.12.1</version>
           </dependency>
         </dependencies>
         <executions>
@@ -386,7 +395,7 @@ and flyway or liquibase.
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <id>default-prepare-agent</id>

--- a/src/test/java/space/testflight/DockerImageCleanerTest.java
+++ b/src/test/java/space/testflight/DockerImageCleanerTest.java
@@ -46,7 +46,7 @@ class DockerImageCleanerTest {
 
   @BeforeEach
   void tagImage() {
-    try (PostgreSQLContainer<?> postgreSqlContainer = new PostgreSQLContainer<>()) {
+    try (PostgreSQLContainer<?> postgreSqlContainer = new PostgreSQLContainer<>("postgres:15.2")) {
       postgreSqlContainer.start();
       String commitedImage = client.commitCmd(postgreSqlContainer.getContainerId()).exec();
       client.tagImageCmd(commitedImage, PostgreSQLContainer.IMAGE, TESTFLIGHT_PREFIX + hashCode()).exec();

--- a/src/test/java/space/testflight/mysql/SpecificMySqlVersionTest.java
+++ b/src/test/java/space/testflight/mysql/SpecificMySqlVersionTest.java
@@ -38,7 +38,7 @@ import space.testflight.model.Customer;
 
 @Flyway(
   database = DatabaseType.MYSQL,
-  dockerImage = "mysql:8.0.28",
+  dockerImage = "mysql:8.0.33",
   testDataScripts = {"db/testdata/init.sql", "db/testdata/initTwo.sql"},
   configuration = {
     @ConfigProperty(key = "flyway.locations", value = "db/mysql"),

--- a/src/test/java/space/testflight/postgresql/PerTestClassTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestClassTest.java
@@ -47,7 +47,7 @@ import space.testflight.model.Customer;
     @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
   }
 )
-@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 class PerTestClassTest {
 
   private static EntityManagerFactory entityManagerFactory;

--- a/src/test/java/space/testflight/postgresql/PerTestExecutionTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestExecutionTest.java
@@ -49,7 +49,7 @@ import space.testflight.model.Customer;
     @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
   }
 )
-@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 class PerTestExecutionTest {
 
   private static EntityManagerFactory entityManagerFactory;

--- a/src/test/java/space/testflight/postgresql/PerTestMethodTest.java
+++ b/src/test/java/space/testflight/postgresql/PerTestMethodTest.java
@@ -49,7 +49,7 @@ import space.testflight.model.Customer;
     @ConfigProperty(key = "space.testflight.jdbc.password.property", value = "javax.persistence.jdbc.password")
   }
 )
-@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 class PerTestMethodTest {
 
   private static EntityManagerFactory entityManagerFactory;


### PR DESCRIPTION
This PR updates the dependencies, especially in order to enable Apple Silicon support.
On the way, the usage of some (now) deprecated API is corrected.